### PR TITLE
Fix printer gui

### DIFF
--- a/src/main/java/pcl/openprinter/ClientProxy.java
+++ b/src/main/java/pcl/openprinter/ClientProxy.java
@@ -28,7 +28,6 @@ public class ClientProxy extends CommonProxy {
 		if (OpenPrinter.render3D) {
 			TileEntitySpecialRenderer render = new PrinterRenderer();
 			ClientRegistry.bindTileEntitySpecialRenderer(pcl.openprinter.tileentity.PrinterTE.class, render);
-			NetworkRegistry.INSTANCE.registerGuiHandler(OpenPrinter.instance, new PrinterGUIHandler());
 			MinecraftForgeClient.registerItemRenderer(Item.getItemFromBlock(OpenPrinter.printerBlock), new ItemPrinterRenderer(render, new PrinterTE()));
 		}
 	}

--- a/src/main/java/pcl/openprinter/OpenPrinter.java
+++ b/src/main/java/pcl/openprinter/OpenPrinter.java
@@ -128,7 +128,6 @@ public class OpenPrinter {
 		ItemStack lprinterPaper	= new ItemStack(printerPaper,64);
 		ItemStack stackPaper	= new ItemStack(Items.paper,64);
 
-
 		GameRegistry.addRecipe(new ShapedOreRecipe( new ItemStack(printerBlock, 1), 
 				"IRI",
 				"MPM",
@@ -169,5 +168,7 @@ public class OpenPrinter {
 
 
 		proxy.registerRenderers();
+
+        NetworkRegistry.INSTANCE.registerGuiHandler(OpenPrinter.instance, new PrinterGUIHandler());
 	}
 }

--- a/src/main/java/pcl/openprinter/tileentity/PrinterContainer.java
+++ b/src/main/java/pcl/openprinter/tileentity/PrinterContainer.java
@@ -8,6 +8,10 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Caitlyn
  *
@@ -15,18 +19,32 @@ import net.minecraft.item.ItemStack;
 public class PrinterContainer extends Container{
     protected PrinterTE tileEntity;
 
+    private Slot colorInkSlot;
+    private Slot blackInkSlot;
+    private Slot paperSlot;
+    private List<Slot> specialSlots;
+    private List<Slot> outputSlots;
+    private List<Slot> playerSlots;
+    private List<Slot> hotbarSlots;
+
     public PrinterContainer (InventoryPlayer inventoryPlayer, PrinterTE te){
             tileEntity = te;
-            //Color Ink
-            addSlotToContainer(new PrinterInkBlackSlot(tileEntity, 0, 30, 17));
             //Black Ink
-            addSlotToContainer(new PrinterInkColorSlot(tileEntity, 1, 60, 17));
+            blackInkSlot = addSlotToContainer(new PrinterInkBlackSlot(tileEntity, 0, 30, 17));
+            //Color Ink
+            colorInkSlot = addSlotToContainer(new PrinterInkColorSlot(tileEntity, 1, 60, 17));
             //Blank Paper
-            addSlotToContainer(new PrinterPaperSlot(tileEntity, 2, 129, 17));
+            paperSlot = addSlotToContainer(new PrinterPaperSlot(tileEntity, 2, 129, 17));
+
+            specialSlots = new ArrayList<Slot>();
+            specialSlots.add(blackInkSlot);
+            specialSlots.add(colorInkSlot);
+            specialSlots.add(paperSlot);
 
             //Output slots
+            outputSlots = new ArrayList<Slot>();
             for (int i = 3; i < 12; i++) {
-            	addSlotToContainer(new Slot(tileEntity, i, 8 + i * 18 - 54, 57));
+            	outputSlots.add(addSlotToContainer(new Slot(tileEntity, i, 8 + i * 18 - 54, 57)));
             }
             
             //commonly used vanilla code that adds the player's inventory
@@ -40,14 +58,16 @@ public class PrinterContainer extends Container{
 
 
     protected void bindPlayerInventory(InventoryPlayer inventoryPlayer) {
+            playerSlots = new ArrayList<Slot>();
             for (int i = 0; i < 3; i++) {
                     for (int j = 0; j < 9; j++) {
-                            addSlotToContainer(new Slot(inventoryPlayer, j + i * 9 + 9, 8 + j * 18, 84 + i * 18));
+                            playerSlots.add(addSlotToContainer(new Slot(inventoryPlayer, j + i * 9 + 9, 8 + j * 18, 84 + i * 18)));
                     }
             }
 
+            hotbarSlots = new ArrayList<Slot>();
             for (int i = 0; i < 9; i++) {
-                    addSlotToContainer(new Slot(inventoryPlayer, i, 8 + i * 18, 142));
+                    hotbarSlots.add(addSlotToContainer(new Slot(inventoryPlayer, i, 8 + i * 18, 142)));
             }
     }
 
@@ -56,21 +76,49 @@ public class PrinterContainer extends Container{
             ItemStack stack = null;
             Slot slotObject = (Slot) inventorySlots.get(slot);
 
+            int outputSlotStart = outputSlots.get(0).slotNumber;
+            int outputSlotEnd = outputSlots.get(outputSlots.size() - 1).slotNumber + 1;
+
+            // Assume inventory and hotbar slot IDs are contiguous
+            int inventoryStart = playerSlots.get(0).slotNumber;
+            int hotbarStart = hotbarSlots.get(0).slotNumber;
+            int hotbarEnd = hotbarSlots.get(hotbarSlots.size() - 1).slotNumber + 1;
+
             //null checks and checks if the item can be stacked (maxStackSize > 1)
             if (slotObject != null && slotObject.getHasStack()) {
                     ItemStack stackInSlot = slotObject.getStack();
                     stack = stackInSlot.copy();
 
-                    //merges the item into player inventory since its in the tileEntity
-                    if (slot < 11) {
-                            if (!this.mergeItemStack(stackInSlot, 0, 35, true)) {
-                                    return null;
-                            }
-                    }
-                    //places it into the tileEntity is possible since its in the player inventory
-                    else if (!this.mergeItemStack(stackInSlot, 0, 9, false)) {
+                    // Try merge output into inventory and signal change
+                    if (slot >= outputSlotStart && slot < outputSlotEnd) {
+                        if (!mergeItemStack(stackInSlot, inventoryStart, hotbarEnd, true))
                             return null;
+                        slotObject.onSlotChange(stackInSlot, stack);
                     }
+                    // Try merge stacks within inventory and hotbar spaces
+                    else if (slot >= inventoryStart && slot < hotbarEnd) {
+                        // If the item is a 'special' item, try putting it into its special slot
+                        boolean handledSpecialItem = false;
+                        for (Slot ss : specialSlots) {
+                            if (!tileEntity.isItemValidForSlot(ss.getSlotIndex(), stackInSlot))
+                                continue;
+                            handledSpecialItem = mergeItemStack(stackInSlot, ss.slotNumber, ss.slotNumber + 1, false);
+                            if (handledSpecialItem)
+                                break;
+                        }
+
+                        // Else treat it like any normal item
+                        if (!handledSpecialItem) {
+                            if (slot >= inventoryStart && slot < hotbarStart) {
+                                if (!mergeItemStack(stackInSlot, hotbarStart, hotbarEnd, false))
+                                    return null;
+                            } else if (slot >= hotbarStart && slot < hotbarEnd && !this.mergeItemStack(stackInSlot, inventoryStart, hotbarStart, false))
+                                return null;
+                        }
+                    }
+                    // Try merge stack into inventory
+                    else if (!mergeItemStack(stackInSlot, inventoryStart, hotbarEnd, false))
+                        return null;
 
                     if (stackInSlot.stackSize == 0) {
                             slotObject.putStack(null);


### PR DESCRIPTION
Fixes two issues with the printer GUI in 1.7.x:
- Printer GUI not registered with server, causing player inventory to be manipulated on server instead of printer inventory.
- Slot indexes incorrect, causing strange transfer and merge behavior.
