### PR TITLE
Fix paper roll

### DIFF
--- a/src/main/java/pcl/openprinter/OpenPrinter.java
+++ b/src/main/java/pcl/openprinter/OpenPrinter.java
@@ -5,24 +5,17 @@ package pcl.openprinter;
  *
  */
 import java.net.URL;
-import java.util.logging.Logger;
 
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.PlayerEvent;
 import pcl.openprinter.blocks.Printer;
+import pcl.openprinter.items.*;
 import pcl.openprinter.tileentity.PrinterTE;
 import pcl.openprinter.gui.PrinterGUIHandler;
-import pcl.openprinter.items.ItemPrinterBlock;
-import pcl.openprinter.items.PrintedPage;
-import pcl.openprinter.items.PrinterInkBlack;
-import pcl.openprinter.items.PrinterInkColor;
-import pcl.openprinter.items.PrinterPaperRoll;
-import pcl.openprinter.BuildInfo;
 import net.minecraftforge.common.config.Configuration;
-import net.minecraftforge.common.config.Property;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraft.block.Block;
-import net.minecraft.block.material.Material;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
@@ -34,13 +27,10 @@ import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
-import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.common.registry.LanguageRegistry;
-import li.cil.oc.api.Blocks;
-import li.cil.oc.api.CreativeTab;
+
 import static li.cil.oc.api.Items.*;
 
 
@@ -145,16 +135,7 @@ public class OpenPrinter {
 				" I ",
 				'R', redInk, 'G', greenInk, 'B', blueInk, 'I', nuggetIron));
 
-
-		GameRegistry.addRecipe( new ItemStack(printerPaperRoll, 1), 
-				"PP",
-				"PP",
-				'P', lprinterPaper);
-
-		GameRegistry.addRecipe( new ItemStack(printerPaperRoll, 1), 
-				"PP",
-				"PP",
-				'P', stackPaper);
+        GameRegistry.addRecipe(new PrinterPaperRollRecipe());
 
 		GameRegistry.addRecipe( new ItemStack(printerInkColor, 1),
 				"RGB",
@@ -166,8 +147,18 @@ public class OpenPrinter {
 				" Z ",
 				'B', blackInk, 'Z', new ItemStack(printerInkBlack, 1, OreDictionary.WILDCARD_VALUE));
 
-
-
+        FMLCommonHandler.instance().bus().register(this);
 		proxy.registerRenderers();
 	}
+
+    @SubscribeEvent
+    public void handleCrafting (PlayerEvent.ItemCraftedEvent event) {
+        if (event.crafting.getItem() instanceof PrinterPaperRoll) {
+            for (int i = 0; i < event.craftMatrix.getSizeInventory(); i++) {
+                ItemStack item = event.craftMatrix.getStackInSlot(i);
+                if (item != null)
+                    event.craftMatrix.setInventorySlotContents(i, new ItemStack(item.getItem(), 1, item.getItemDamage()));
+            }
+        }
+    }
 }

--- a/src/main/java/pcl/openprinter/OpenPrinter.java
+++ b/src/main/java/pcl/openprinter/OpenPrinter.java
@@ -9,13 +9,22 @@ import java.net.URL;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.PlayerEvent;
 import pcl.openprinter.blocks.Printer;
-import pcl.openprinter.items.*;
 import pcl.openprinter.tileentity.PrinterTE;
 import pcl.openprinter.gui.PrinterGUIHandler;
+import pcl.openprinter.items.ItemPrinterBlock;
+import pcl.openprinter.items.PrintedPage;
+import pcl.openprinter.items.PrinterInkBlack;
+import pcl.openprinter.items.PrinterInkColor;
+import pcl.openprinter.items.PrinterPaperRoll;
+import pcl.openprinter.items.PrinterPaperRollRecipe;
+import pcl.openprinter.BuildInfo;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.common.config.Property;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
@@ -27,10 +36,13 @@ import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.ModContainer;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
-
+import cpw.mods.fml.common.registry.LanguageRegistry;
+import li.cil.oc.api.Blocks;
+import li.cil.oc.api.CreativeTab;
 import static li.cil.oc.api.Items.*;
 
 

--- a/src/main/java/pcl/openprinter/items/PrinterPaperRollRecipe.java
+++ b/src/main/java/pcl/openprinter/items/PrinterPaperRollRecipe.java
@@ -11,39 +11,31 @@ public class PrinterPaperRollRecipe implements IRecipe
 {
     @Override
     public boolean matches (InventoryCrafting inventory, World world) {
-        if (inventory.getSizeInventory() >= 9)
-            return matches(inventory, 0, 0)
-                || matches(inventory, 1, 0)
-                || matches(inventory, 0, 1)
-                || matches(inventory, 1, 1);
-        else if (inventory.getSizeInventory() >= 4)
-            return matches(inventory, 0, 0);
+        if (inventory.getSizeInventory() >= 9) {
+            ItemStack stack00 = inventory.getStackInRowAndColumn(1, 0);
+            ItemStack stack01 = inventory.getStackInRowAndColumn(0, 1);
+            ItemStack stack10 = inventory.getStackInRowAndColumn(2, 1);
+            ItemStack stack11 = inventory.getStackInRowAndColumn(1, 2);
+
+            if (stack00 == null || stack01 == null || stack10 == null || stack11 == null)
+                return false;
+
+            int emptyCount = 0;
+            for (int i = 0; i < 9; i++) {
+                if (inventory.getStackInSlot(i) == null)
+                    emptyCount++;
+            }
+
+            if (emptyCount != 5)
+                return false;
+
+            return stack00.getItem() == Items.paper && stack00.stackSize == 64
+                && stack01.getItem() == Items.paper && stack01.stackSize == 64
+                && stack10.getItem() == Items.paper && stack10.stackSize == 64
+                && stack11.getItem() == Items.paper && stack11.stackSize == 64;
+        }
         else
             return false;
-    }
-
-    private boolean matches (InventoryCrafting inventory, int offsetX, int offsetY) {
-        ItemStack stack00 = inventory.getStackInRowAndColumn(0 + offsetX, 0 + offsetY);
-        ItemStack stack01 = inventory.getStackInRowAndColumn(1 + offsetX, 0 + offsetY);
-        ItemStack stack10 = inventory.getStackInRowAndColumn(0 + offsetX, 1 + offsetY);
-        ItemStack stack11 = inventory.getStackInRowAndColumn(1 + offsetX, 1 + offsetY);
-
-        if (stack00 == null || stack01 == null || stack10 == null || stack11 == null)
-            return false;
-
-        int emptyCount = 0;
-        for (int i = 0; i < 9; i++) {
-            if (inventory.getStackInSlot(i) == null)
-                emptyCount++;
-        }
-
-        if (emptyCount != 5)
-            return false;
-
-        return stack00.getItem() == Items.paper && stack00.stackSize == 64
-            && stack01.getItem() == Items.paper && stack01.stackSize == 64
-            && stack10.getItem() == Items.paper && stack10.stackSize == 64
-            && stack11.getItem() == Items.paper && stack11.stackSize == 64;
     }
 
     @Override

--- a/src/main/java/pcl/openprinter/items/PrinterPaperRollRecipe.java
+++ b/src/main/java/pcl/openprinter/items/PrinterPaperRollRecipe.java
@@ -1,0 +1,63 @@
+package pcl.openprinter.items;
+
+import net.minecraft.init.Items;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.world.World;
+import pcl.openprinter.OpenPrinter;
+
+public class PrinterPaperRollRecipe implements IRecipe
+{
+    @Override
+    public boolean matches (InventoryCrafting inventory, World world) {
+        if (inventory.getSizeInventory() >= 9)
+            return matches(inventory, 0, 0)
+                || matches(inventory, 1, 0)
+                || matches(inventory, 0, 1)
+                || matches(inventory, 1, 1);
+        else if (inventory.getSizeInventory() >= 4)
+            return matches(inventory, 0, 0);
+        else
+            return false;
+    }
+
+    private boolean matches (InventoryCrafting inventory, int offsetX, int offsetY) {
+        ItemStack stack00 = inventory.getStackInRowAndColumn(0 + offsetX, 0 + offsetY);
+        ItemStack stack01 = inventory.getStackInRowAndColumn(1 + offsetX, 0 + offsetY);
+        ItemStack stack10 = inventory.getStackInRowAndColumn(0 + offsetX, 1 + offsetY);
+        ItemStack stack11 = inventory.getStackInRowAndColumn(1 + offsetX, 1 + offsetY);
+
+        if (stack00 == null || stack01 == null || stack10 == null || stack11 == null)
+            return false;
+
+        int emptyCount = 0;
+        for (int i = 0; i < 9; i++) {
+            if (inventory.getStackInSlot(i) == null)
+                emptyCount++;
+        }
+
+        if (emptyCount != 5)
+            return false;
+
+        return stack00.getItem() == Items.paper && stack00.stackSize == 64
+            && stack01.getItem() == Items.paper && stack01.stackSize == 64
+            && stack10.getItem() == Items.paper && stack10.stackSize == 64
+            && stack11.getItem() == Items.paper && stack11.stackSize == 64;
+    }
+
+    @Override
+    public ItemStack getCraftingResult (InventoryCrafting inventory) {
+        return new ItemStack(OpenPrinter.printerPaperRoll, 1);
+    }
+
+    @Override
+    public int getRecipeSize () {
+        return 9;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput () {
+        return new ItemStack(OpenPrinter.printerPaperRoll, 1);
+    }
+}


### PR DESCRIPTION
1.7.  Replaces the paper roll recipe with an IRecipe implementation and crafting event handler to correctly consume 64 pages per slot stack.
