### PR TITLE
Update en_US.lang

### DIFF
--- a/src/main/resources/assets/openprinter/lang/en_US.lang
+++ b/src/main/resources/assets/openprinter/lang/en_US.lang
@@ -1,4 +1,4 @@
-tile.printer.name=Open Printer
+tile.printer.name=OpenPrinter
 item.printerPaper.name=Printer Paper
 item.printerPaperRoll.name=Printer Paper Roll
 item.printedPage.name=Printed Page


### PR DESCRIPTION
Changed 'Open Printer' to 'OpenPrinter' on the actual printer block for consistency with OpenLights' 'OpenLight'.
