### PR TITLE
Return of boolean expressions should not be wrapped into an "if-then-else" statement

### DIFF
--- a/src/main/java/pcl/openprinter/blocks/BlockFileCabinet.java
+++ b/src/main/java/pcl/openprinter/blocks/BlockFileCabinet.java
@@ -80,21 +80,13 @@ public class BlockFileCabinet extends BlockContainer {
 
 	@Override
 	public boolean isOpaqueCube() {
-		if (OpenPrinter.render3D) {
-			return false;
-		} else {
-			return true;
-		}
+		return !OpenPrinter.render3D;
 
 	}
 
 	@Override
 	public boolean renderAsNormalBlock() {
-		if (OpenPrinter.render3D) {
-			return false;
-		} else {
-			return true;
-		}
+		return !OpenPrinter.render3D;
 	}
 
 	@Override

--- a/src/main/java/pcl/openprinter/blocks/BlockPrinter.java
+++ b/src/main/java/pcl/openprinter/blocks/BlockPrinter.java
@@ -133,21 +133,13 @@ public class BlockPrinter extends BlockContainer {
 
 	@Override
 	public boolean isOpaqueCube() {
-		if (OpenPrinter.render3D) {
-			return false;
-		} else {
-			return true;
-		}
+		return !OpenPrinter.render3D;
 
 	}
 
 	@Override
 	public boolean renderAsNormalBlock() {
-		if (OpenPrinter.render3D) {
-			return false;
-		} else {
-			return true;
-		}
+		return !OpenPrinter.render3D;
 	}
 
 	@Override

--- a/src/main/java/pcl/openprinter/blocks/BlockShredder.java
+++ b/src/main/java/pcl/openprinter/blocks/BlockShredder.java
@@ -80,21 +80,13 @@ public class BlockShredder extends BlockContainer {
 
 	@Override
 	public boolean isOpaqueCube() {
-		if (OpenPrinter.render3D) {
-			return false;
-		} else {
-			return true;
-		}
+		return !OpenPrinter.render3D;
 
 	}
 
 	@Override
 	public boolean renderAsNormalBlock() {
-		if (OpenPrinter.render3D) {
-			return false;
-		} else {
-			return true;
-		}
+		return !OpenPrinter.render3D;
 	}
 
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1126 - “Return of boolean expressions should not be wrapped into an "if-then-else" statement”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1126
Please let me know if you have any questions.
Ayman Abdelghany.
