### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/src/main/java/pcl/openprinter/BuildInfo.java
+++ b/src/main/java/pcl/openprinter/BuildInfo.java
@@ -13,6 +13,9 @@ public class BuildInfo {
 	public static final String versionNumber = "@VERSION@";
 	public static final String buildNumber = "@BUILD@";
 
+	private BuildInfo() {
+	}
+
 	public static int getBuildNumber() {
 		if (buildNumber.equals("@" + "BUILD" + "@"))
 			return 0;

--- a/src/main/java/pcl/openprinter/ContentRegistry.java
+++ b/src/main/java/pcl/openprinter/ContentRegistry.java
@@ -39,8 +39,11 @@ public class ContentRegistry {
 	public static Item  shreddedPaper;
 	public static Item  folder;
 	public static ItemBlock  printeritemBlock;
-	
-    // Called on mod preInit()
+
+	private ContentRegistry() {
+	}
+
+	// Called on mod preInit()
 	public static void preInit() {
         registerBlocks();
         registerItems();

--- a/src/main/java/pcl/openprinter/network/PacketHandler.java
+++ b/src/main/java/pcl/openprinter/network/PacketHandler.java
@@ -7,8 +7,11 @@ import cpw.mods.fml.relauncher.Side;
 
  public class PacketHandler {
    public static final SimpleNetworkWrapper INSTANCE = NetworkRegistry.INSTANCE.newSimpleChannel("openprinter");
-   
-   public static void init() {
+
+     private PacketHandler() {
+     }
+
+     public static void init() {
      INSTANCE.registerMessage(GUIFolderMessageHandlerServer.class, MessageGUIFolder.class, 0, Side.SERVER);
      INSTANCE.registerMessage(GUIFolderMessageHandlerClient.class, MessageGUIFolder.class, 0, Side.CLIENT);
    }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
