### PR TITLE
Add variable text width awareness to text rendering code

### DIFF
--- a/src/main/java/pcl/openprinter/OpenPrinter.java
+++ b/src/main/java/pcl/openprinter/OpenPrinter.java
@@ -28,6 +28,7 @@ import net.minecraftforge.fml.common.network.NetworkRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import pcl.openprinter.util.ocLootDisk;
+import pcl.openprinter.util.CharacterWidth;
 
 
 @Mod(
@@ -54,9 +55,11 @@ public class OpenPrinter {
 	public static CreativeTabs CreativeTab = new CreativeTab("OpenPrinter");
 	
 	private static ContentRegistry contentRegistry = new ContentRegistry();
+
 	
 	@EventHandler
 	public void preInit(FMLPreInitializationEvent event) {
+                CharacterWidth.initWidths();
 		MinecraftForge.EVENT_BUS.register(contentRegistry);
 
 		PacketHandler.init();

--- a/src/main/java/pcl/openprinter/gui/PaperGUI.java
+++ b/src/main/java/pcl/openprinter/gui/PaperGUI.java
@@ -17,6 +17,8 @@ import net.minecraftforge.common.util.Constants;
 
 import java.awt.*;
 
+import pcl.openprinter.util.CharacterWidth;
+
 /**
  * @author Caitlyn
  * 
@@ -84,7 +86,7 @@ public class PaperGUI extends GuiScreen {
 				if(parts.length > 1) {
 					Integer outleng = parts[0].replaceAll("(?:§[0-9a-fk-or])+", "").length();
 					if (outleng > 30) {
-						parts[0] = limit(parts[0],30);
+						parts[0] = CharacterWidth.limitWidth(parts[0],164);
 					}
 					Integer color = Integer.parseInt(parts[1]);
 					String alignment = parts[2];
@@ -129,7 +131,7 @@ public class PaperGUI extends GuiScreen {
 				if(parts.length > 1) {
 					Integer outleng = parts[0].replaceAll("(?:§[0-9a-fk-or])+", "").length();
 					if (outleng > 30) {
-						parts[0] = limit(parts[0],30);
+						parts[0] = CharacterWidth.limitWidth(parts[0],164);
 					}
 
 					Integer color = 0;

--- a/src/main/java/pcl/openprinter/tileentity/PrinterTE.java
+++ b/src/main/java/pcl/openprinter/tileentity/PrinterTE.java
@@ -37,6 +37,7 @@ import pcl.openprinter.items.PrinterInkBlack;
 import pcl.openprinter.items.PrinterInkColor;
 import pcl.openprinter.items.PrinterPaperRoll;
 import pcl.openprinter.util.ItemUtils;
+import pcl.openprinter.util.CharacterWidth;
 
 import javax.annotation.Nonnull;
 
@@ -558,6 +559,16 @@ public class PrinterTE extends TileEntity implements ITickable, Environment {
 	public Object[] charCount(Context context, Arguments args) {
 		return new Object[] { args.checkString(0).replaceAll("(?:§[0-9a-fk-or])+", "").length() };
 	}
+
+        @Callback(doc = "function(String:input):Integer; -- gets the pixel width of a given String", direct = true)
+        public Object[] width(Context context, Arguments args) {
+		return new Object[] { CharacterWidth.calculateWidth(args.checkString(0)) };
+        }
+
+        @Callback(doc = "function():Integer; -- returns the maximum allowed width of a line", direct = true)
+        public Object[] maxWidth(Context context, Arguments args) {
+		return new Object[] { 164 };
+        }
 
 	@Callback(doc = "function():boolean; -- clears the printer buffer")
 	public Object[] clear(Context context, Arguments args) {

--- a/src/main/java/pcl/openprinter/util/CharacterWidth.java
+++ b/src/main/java/pcl/openprinter/util/CharacterWidth.java
@@ -43,7 +43,7 @@ public class CharacterWidth {
         int offset = 0;
         for (int i = 0; i < str.length(); i++) {
             if (cc) {
-                // assume any bold character is an extra character wide
+                // assume any bold character is an extra pixel wide
                 switch (Character.toString(str.charAt(i))) {
                     case "l":
                         offset = 1;

--- a/src/main/java/pcl/openprinter/util/CharacterWidth.java
+++ b/src/main/java/pcl/openprinter/util/CharacterWidth.java
@@ -1,0 +1,83 @@
+package pcl.openprinter.util;
+
+public class CharacterWidth {
+    private static int CharacterWidths[] = new int[128];
+
+    public static void initWidths() {
+        /* I'm sorry */
+        for (int i = 0; i < CharacterWidths.length; i++) {
+            CharacterWidths[i] = 5;
+        }
+        CharacterWidths[32] = 3;
+        CharacterWidths[33] = 1;
+        CharacterWidths[34] = 3;
+        CharacterWidths[39] = 1;
+        CharacterWidths[40] = 3;
+        CharacterWidths[41] = 3;
+        CharacterWidths[42] = 3;
+        CharacterWidths[44] = 1;
+        CharacterWidths[46] = 1;
+        CharacterWidths[58] = 1;
+        CharacterWidths[59] = 1;
+        CharacterWidths[60] = 4;
+        CharacterWidths[62] = 4;
+        CharacterWidths[64] = 6;
+        CharacterWidths[73] = 3;
+        CharacterWidths[91] = 3;
+        CharacterWidths[93] = 3;
+        CharacterWidths[96] = 2;
+        CharacterWidths[102] = 4;
+        CharacterWidths[105] = 1;
+        CharacterWidths[107] = 4;
+        CharacterWidths[108] = 2;
+        CharacterWidths[116] = 3;
+        CharacterWidths[123] = 3;
+        CharacterWidths[124] = 1;
+        CharacterWidths[125] = 3;
+        CharacterWidths[126] = 6;
+    }
+    public static int calculateWidth(String str) {
+	String dispstr = str.replaceAll("(?:§[0-9a-fk-or])+", "");
+        int rlen = dispstr.length();
+        boolean cc = false;
+        int offset = 0;
+        for (int i = 0; i < str.length(); i++) {
+            if (cc) {
+                // assume any bold character is an extra character wide
+                switch (Character.toString(str.charAt(i))) {
+                    case "l":
+                        offset = 1;
+                        System.out.println("Setting bold.");
+                        break;
+                    case "r":
+                        offset = 0;
+                        break;
+                }
+                cc = false;
+            } else {
+                if (str.charAt(i) == ("§").charAt(0)) {
+                    cc =  true;
+                } else {
+                    rlen = rlen + offset;
+                    if ((int) str.charAt(i) > CharacterWidths.length) {
+                        rlen = rlen + 5;
+                    } else {
+                        rlen = rlen + CharacterWidths[(int) str.charAt(i)];
+                    }
+                }
+            }
+        }
+        return rlen;
+    }
+    public static String limitWidth(String str, int limit) {
+        String rstr = "";
+        for (int i = 0; i < str.length(); i++) {
+            if (calculateWidth(rstr.concat(Character.toString(str.charAt(i)))) < limit) {
+                rstr = rstr.concat(Character.toString(str.charAt(i)));
+            } else {
+                break;
+            }
+        }
+        return rstr;
+    }
+}


### PR DESCRIPTION
Currently, OpenPrinter imposes a flat 30 character limit on the length of a line. This mildly annoyed me, and as everything I do seems to be annoyance-driven development, I fixed it. It uses a lookup table for ASCII characters, filled with stuff I found on the Minecraft wiki, to calculate the width of each character, and limits the displayed with to what fits on the page (approximately 165 character pixels). Rather than implementing another lookup table for bold characters, I just count each as being an extra pixel wide, though many are only an extra 0.5 pixels wide.

Also included is a pair of functions, exposed as part of the component - `width` and `maxWidth` - so software can do more intelligent typesetting.

Some comparisons:
Before:
![Before](https://github.com/PC-Logix/OpenPrinter/assets/3684161/bf75d4d7-10d8-4b12-96a2-c88842e83427)

After:
![After](https://github.com/PC-Logix/OpenPrinter/assets/3684161/8bc13c0f-52a4-4954-9967-428489ff051a)

I don't claim it's well written, but it functions.